### PR TITLE
Add Line Mode diff methods to the public API

### DIFF
--- a/java/src/name/fraser/neil/plaintext/diff_match_patch.java
+++ b/java/src/name/fraser/neil/plaintext/diff_match_patch.java
@@ -81,12 +81,12 @@ public class diff_match_patch {
    * Internal class for returning results from diff_linesToChars().
    * Other less paranoid languages just use a three-element array.
    */
-  protected static class LinesToCharsResult {
-    protected String chars1;
-    protected String chars2;
-    protected List<String> lineArray;
+  public static class LinesToCharsResult {
+    public String chars1;
+    public String chars2;
+    public List<String> lineArray;
 
-    protected LinesToCharsResult(String chars1, String chars2,
+    public LinesToCharsResult(String chars1, String chars2,
         List<String> lineArray) {
       this.chars1 = chars1;
       this.chars2 = chars2;
@@ -500,7 +500,7 @@ public class diff_match_patch {
    *     the List of unique strings.  The zeroth element of the List of
    *     unique strings is intentionally blank.
    */
-  protected LinesToCharsResult diff_linesToChars(String text1, String text2) {
+  public LinesToCharsResult diff_linesToChars(String text1, String text2) {
     List<String> lineArray = new ArrayList<String>();
     Map<String, Integer> lineHash = new HashMap<String, Integer>();
     // e.g. linearray[4] == "Hello\n"
@@ -565,7 +565,7 @@ public class diff_match_patch {
    * @param diffs List of Diff objects.
    * @param lineArray List of unique strings.
    */
-  protected void diff_charsToLines(List<Diff> diffs,
+  public void diff_charsToLines(List<Diff> diffs,
                                   List<String> lineArray) {
     StringBuilder text;
     for (Diff diff : diffs) {

--- a/java/tests/name/fraser/neil/plaintext/apitest/diff_match_patch_apitest.java
+++ b/java/tests/name/fraser/neil/plaintext/apitest/diff_match_patch_apitest.java
@@ -16,28 +16,28 @@
  * limitations under the License.
  */
 
-/**
- * Compile from diff-match-patch/java with:
- * javac -d classes src/name/fraser/neil/plaintext/diff_match_patch.java tests/name/fraser/neil/plaintext/diff_match_patch_test.java
- * Execute with:
- * java -classpath classes name/fraser/neil/plaintext/diff_match_patch_test
- */
-
-package name.fraser.neil.plaintext;
+package name.fraser.neil.plaintext.apitest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import name.fraser.neil.plaintext.diff_match_patch;
 import name.fraser.neil.plaintext.diff_match_patch.Diff;
 import name.fraser.neil.plaintext.diff_match_patch.LinesToCharsResult;
 import name.fraser.neil.plaintext.diff_match_patch.Patch;
 
-public class diff_match_patch_test {
+/**
+ * Tests the public API. This test class is deliberately located in a different package from the diff_match_patch class so that we cannot cheat
+ * and access methods that were not intended for public consumption.
+ *
+ * Compile from diff-match-patch/java with:
+ * javac -d classes src/name/fraser/neil/plaintext/diff_match_patch.java tests/name/fraser/neil/plaintext/apitest/diff_match_patch_apitest.java
+ * Execute with:
+ * java -classpath classes name/fraser/neil/plaintext/apitest/diff_match_patch_apitest
+ */
+public class diff_match_patch_apitest {
 
   private static diff_match_patch dmp;
   private static diff_match_patch.Operation DELETE = diff_match_patch.Operation.DELETE;
@@ -47,67 +47,6 @@ public class diff_match_patch_test {
 
   //  DIFF TEST FUNCTIONS
 
-
-  public static void testDiffCommonPrefix() {
-    // Detect any common prefix.
-    assertEquals("diff_commonPrefix: Null case.", 0, dmp.diff_commonPrefix("abc", "xyz"));
-
-    assertEquals("diff_commonPrefix: Non-null case.", 4, dmp.diff_commonPrefix("1234abcdef", "1234xyz"));
-
-    assertEquals("diff_commonPrefix: Whole case.", 4, dmp.diff_commonPrefix("1234", "1234xyz"));
-  }
-
-  public static void testDiffCommonSuffix() {
-    // Detect any common suffix.
-    assertEquals("diff_commonSuffix: Null case.", 0, dmp.diff_commonSuffix("abc", "xyz"));
-
-    assertEquals("diff_commonSuffix: Non-null case.", 4, dmp.diff_commonSuffix("abcdef1234", "xyz1234"));
-
-    assertEquals("diff_commonSuffix: Whole case.", 4, dmp.diff_commonSuffix("1234", "xyz1234"));
-  }
-
-  public static void testDiffCommonOverlap() {
-    // Detect any suffix/prefix overlap.
-    assertEquals("diff_commonOverlap: Null case.", 0, dmp.diff_commonOverlap("", "abcd"));
-
-    assertEquals("diff_commonOverlap: Whole case.", 3, dmp.diff_commonOverlap("abc", "abcd"));
-
-    assertEquals("diff_commonOverlap: No overlap.", 0, dmp.diff_commonOverlap("123456", "abcd"));
-
-    assertEquals("diff_commonOverlap: Overlap.", 3, dmp.diff_commonOverlap("123456xxx", "xxxabcd"));
-
-    // Some overly clever languages (C#) may treat ligatures as equal to their
-    // component letters.  E.g. U+FB01 == 'fi'
-    assertEquals("diff_commonOverlap: Unicode.", 0, dmp.diff_commonOverlap("fi", "\ufb01i"));
-  }
-
-  public static void testDiffHalfmatch() {
-    // Detect a halfmatch.
-    dmp.Diff_Timeout = 1;
-    assertNull("diff_halfMatch: No match #1.", dmp.diff_halfMatch("1234567890", "abcdef"));
-
-    assertNull("diff_halfMatch: No match #2.", dmp.diff_halfMatch("12345", "23"));
-
-    assertArrayEquals("diff_halfMatch: Single Match #1.", new String[]{"12", "90", "a", "z", "345678"}, dmp.diff_halfMatch("1234567890", "a345678z"));
-
-    assertArrayEquals("diff_halfMatch: Single Match #2.", new String[]{"a", "z", "12", "90", "345678"}, dmp.diff_halfMatch("a345678z", "1234567890"));
-
-    assertArrayEquals("diff_halfMatch: Single Match #3.", new String[]{"abc", "z", "1234", "0", "56789"}, dmp.diff_halfMatch("abc56789z", "1234567890"));
-
-    assertArrayEquals("diff_halfMatch: Single Match #4.", new String[]{"a", "xyz", "1", "7890", "23456"}, dmp.diff_halfMatch("a23456xyz", "1234567890"));
-
-    assertArrayEquals("diff_halfMatch: Multiple Matches #1.", new String[]{"12123", "123121", "a", "z", "1234123451234"}, dmp.diff_halfMatch("121231234123451234123121", "a1234123451234z"));
-
-    assertArrayEquals("diff_halfMatch: Multiple Matches #2.", new String[]{"", "-=-=-=-=-=", "x", "", "x-=-=-=-=-=-=-="}, dmp.diff_halfMatch("x-=-=-=-=-=-=-=-=-=-=-=-=", "xx-=-=-=-=-=-=-="));
-
-    assertArrayEquals("diff_halfMatch: Multiple Matches #3.", new String[]{"-=-=-=-=-=", "", "", "y", "-=-=-=-=-=-=-=y"}, dmp.diff_halfMatch("-=-=-=-=-=-=-=-=-=-=-=-=y", "-=-=-=-=-=-=-=yy"));
-
-    // Optimal diff would be -q+x=H-i+e=lloHe+Hu=llo-Hew+y not -qHillo+x=HelloHe-w+Hulloy
-    assertArrayEquals("diff_halfMatch: Non-optimal halfmatch.", new String[]{"qHillo", "w", "x", "Hulloy", "HelloHe"}, dmp.diff_halfMatch("qHilloHelloHew", "xHelloHeHulloy"));
-
-    dmp.Diff_Timeout = 0;
-    assertNull("diff_halfMatch: Optimal no halfmatch.", dmp.diff_halfMatch("qHilloHelloHew", "xHelloHeHulloy"));
-  }
 
   public static void testDiffLinesToChars() {
     // Convert lines down to characters.
@@ -468,21 +407,6 @@ public class diff_match_patch_test {
     assertEquals("diff_levenshtein: Levenshtein with middle equality.", 7, dmp.diff_levenshtein(diffs));
   }
 
-  public static void testDiffBisect() {
-    // Normal.
-    String a = "cat";
-    String b = "map";
-    // Since the resulting diff hasn't been normalized, it would be ok if
-    // the insertion and deletion pairs are swapped.
-    // If the order changes, tweak this test as required.
-    LinkedList<Diff> diffs = diffList(new Diff(DELETE, "c"), new Diff(INSERT, "m"), new Diff(EQUAL, "a"), new Diff(DELETE, "t"), new Diff(INSERT, "p"));
-    assertEquals("diff_bisect: Normal.", diffs, dmp.diff_bisect(a, b, Long.MAX_VALUE));
-
-    // Timeout.
-    diffs = diffList(new Diff(DELETE, "cat"), new Diff(INSERT, "map"));
-    assertEquals("diff_bisect: Timeout.", diffs, dmp.diff_bisect(a, b, 0));
-  }
-
   public static void testDiffMain() {
     // Perform a trivial diff.
     LinkedList<Diff> diffs = diffList();
@@ -575,63 +499,6 @@ public class diff_match_patch_test {
   //  MATCH TEST FUNCTIONS
 
 
-  public static void testMatchAlphabet() {
-    // Initialise the bitmasks for Bitap.
-    Map<Character, Integer> bitmask;
-    bitmask = new HashMap<Character, Integer>();
-    bitmask.put('a', 4); bitmask.put('b', 2); bitmask.put('c', 1);
-    assertEquals("match_alphabet: Unique.", bitmask, dmp.match_alphabet("abc"));
-
-    bitmask = new HashMap<Character, Integer>();
-    bitmask.put('a', 37); bitmask.put('b', 18); bitmask.put('c', 8);
-    assertEquals("match_alphabet: Duplicates.", bitmask, dmp.match_alphabet("abcaba"));
-  }
-
-  public static void testMatchBitap() {
-    // Bitap algorithm.
-    dmp.Match_Distance = 100;
-    dmp.Match_Threshold = 0.5f;
-    assertEquals("match_bitap: Exact match #1.", 5, dmp.match_bitap("abcdefghijk", "fgh", 5));
-
-    assertEquals("match_bitap: Exact match #2.", 5, dmp.match_bitap("abcdefghijk", "fgh", 0));
-
-    assertEquals("match_bitap: Fuzzy match #1.", 4, dmp.match_bitap("abcdefghijk", "efxhi", 0));
-
-    assertEquals("match_bitap: Fuzzy match #2.", 2, dmp.match_bitap("abcdefghijk", "cdefxyhijk", 5));
-
-    assertEquals("match_bitap: Fuzzy match #3.", -1, dmp.match_bitap("abcdefghijk", "bxy", 1));
-
-    assertEquals("match_bitap: Overflow.", 2, dmp.match_bitap("123456789xx0", "3456789x0", 2));
-
-    assertEquals("match_bitap: Before start match.", 0, dmp.match_bitap("abcdef", "xxabc", 4));
-
-    assertEquals("match_bitap: Beyond end match.", 3, dmp.match_bitap("abcdef", "defyy", 4));
-
-    assertEquals("match_bitap: Oversized pattern.", 0, dmp.match_bitap("abcdef", "xabcdefy", 0));
-
-    dmp.Match_Threshold = 0.4f;
-    assertEquals("match_bitap: Threshold #1.", 4, dmp.match_bitap("abcdefghijk", "efxyhi", 1));
-
-    dmp.Match_Threshold = 0.3f;
-    assertEquals("match_bitap: Threshold #2.", -1, dmp.match_bitap("abcdefghijk", "efxyhi", 1));
-
-    dmp.Match_Threshold = 0.0f;
-    assertEquals("match_bitap: Threshold #3.", 1, dmp.match_bitap("abcdefghijk", "bcdef", 1));
-
-    dmp.Match_Threshold = 0.5f;
-    assertEquals("match_bitap: Multiple select #1.", 0, dmp.match_bitap("abcdexyzabcde", "abccde", 3));
-
-    assertEquals("match_bitap: Multiple select #2.", 8, dmp.match_bitap("abcdexyzabcde", "abccde", 5));
-
-    dmp.Match_Distance = 10;  // Strict location.
-    assertEquals("match_bitap: Distance test #1.", -1, dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdefg", 24));
-
-    assertEquals("match_bitap: Distance test #2.", 0, dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdxxefg", 1));
-
-    dmp.Match_Distance = 1000;  // Loose location.
-    assertEquals("match_bitap: Distance test #3.", 0, dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdefg", 24));
-  }
-
   public static void testMatchMain() {
     // Full match.
     assertEquals("match_main: Equality.", 0, dmp.match_main("abcdef", "abcdef", 1000));
@@ -705,26 +572,6 @@ public class diff_match_patch_test {
     strp = "@@ -1,9 +1,9 @@\n-f\n+F\n oo+fooba\n@@ -7,9 +7,9 @@\n obar\n-,\n+.\n  tes\n";
     patches = dmp.patch_fromText(strp);
     assertEquals("patch_toText: Dual.", strp, dmp.patch_toText(patches));
-  }
-
-  public static void testPatchAddContext() {
-    dmp.Patch_Margin = 4;
-    Patch p;
-    p = dmp.patch_fromText("@@ -21,4 +21,10 @@\n-jump\n+somersault\n").get(0);
-    dmp.patch_addContext(p, "The quick brown fox jumps over the lazy dog.");
-    assertEquals("patch_addContext: Simple case.", "@@ -17,12 +17,18 @@\n fox \n-jump\n+somersault\n s ov\n", p.toString());
-
-    p = dmp.patch_fromText("@@ -21,4 +21,10 @@\n-jump\n+somersault\n").get(0);
-    dmp.patch_addContext(p, "The quick brown fox jumps.");
-    assertEquals("patch_addContext: Not enough trailing context.", "@@ -17,10 +17,16 @@\n fox \n-jump\n+somersault\n s.\n", p.toString());
-
-    p = dmp.patch_fromText("@@ -3 +3,2 @@\n-e\n+at\n").get(0);
-    dmp.patch_addContext(p, "The quick brown fox jumps.");
-    assertEquals("patch_addContext: Not enough leading context.", "@@ -1,7 +1,8 @@\n Th\n-e\n+at\n  qui\n", p.toString());
-
-    p = dmp.patch_fromText("@@ -3 +3,2 @@\n-e\n+at\n").get(0);
-    dmp.patch_addContext(p, "The quick brown fox jumps.  The quick brown fox crashes.");
-    assertEquals("patch_addContext: Ambiguity.", "@@ -1,27 +1,28 @@\n Th\n-e\n+at\n  quick brown fox jumps. \n", p.toString());
   }
 
   @SuppressWarnings("deprecation")
@@ -917,12 +764,6 @@ public class diff_match_patch_test {
     }
   }
 
-  private static void assertNull(String error_msg, Object n) {
-    if (n != null) {
-      throw new Error("assertNull fail: " + error_msg);
-    }
-  }
-
   private static void fail(String error_msg) {
     throw new Error("Fail: " + error_msg);
   }
@@ -962,10 +803,6 @@ public class diff_match_patch_test {
   public static void main(String args[]) {
     dmp = new diff_match_patch();
 
-    testDiffCommonPrefix();
-    testDiffCommonSuffix();
-    testDiffCommonOverlap();
-    testDiffHalfmatch();
     testDiffLinesToChars();
     testDiffCharsToLines();
     testDiffCleanupMerge();
@@ -977,17 +814,13 @@ public class diff_match_patch_test {
     testDiffDelta();
     testDiffXIndex();
     testDiffLevenshtein();
-    testDiffBisect();
     testDiffMain();
 
-    testMatchAlphabet();
-    testMatchBitap();
     testMatchMain();
 
     testPatchObj();
     testPatchFromText();
     testPatchToText();
-    testPatchAddContext();
     testPatchMake();
     testPatchSplitMax();
     testPatchAddPadding();

--- a/java/tests/name/fraser/neil/plaintext/diff_match_patch_impltest.java
+++ b/java/tests/name/fraser/neil/plaintext/diff_match_patch_impltest.java
@@ -1,0 +1,250 @@
+/*
+ * Diff Match and Patch -- Test harness
+ * Copyright 2018 The diff-match-patch Authors.
+ * https://github.com/google/diff-match-patch
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package name.fraser.neil.plaintext;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import name.fraser.neil.plaintext.diff_match_patch.Diff;
+import name.fraser.neil.plaintext.diff_match_patch.Patch;
+
+/**
+ * Tests the internal implementation methods.
+ *
+ * Compile from diff-match-patch/java with:
+ * javac -d classes src/name/fraser/neil/plaintext/diff_match_patch.java tests/name/fraser/neil/plaintext/diff_match_patch_impltest.java
+ * Execute with:
+ * java -classpath classes name/fraser/neil/plaintext/diff_match_patch_impltest
+ */
+public class diff_match_patch_impltest {
+
+  private static diff_match_patch dmp;
+  private static diff_match_patch.Operation DELETE = diff_match_patch.Operation.DELETE;
+  private static diff_match_patch.Operation EQUAL = diff_match_patch.Operation.EQUAL;
+  private static diff_match_patch.Operation INSERT = diff_match_patch.Operation.INSERT;
+
+
+  //  DIFF TEST FUNCTIONS
+
+
+  public static void testDiffCommonPrefix() {
+    // Detect any common prefix.
+    assertEquals("diff_commonPrefix: Null case.", 0, dmp.diff_commonPrefix("abc", "xyz"));
+
+    assertEquals("diff_commonPrefix: Non-null case.", 4, dmp.diff_commonPrefix("1234abcdef", "1234xyz"));
+
+    assertEquals("diff_commonPrefix: Whole case.", 4, dmp.diff_commonPrefix("1234", "1234xyz"));
+  }
+
+  public static void testDiffCommonSuffix() {
+    // Detect any common suffix.
+    assertEquals("diff_commonSuffix: Null case.", 0, dmp.diff_commonSuffix("abc", "xyz"));
+
+    assertEquals("diff_commonSuffix: Non-null case.", 4, dmp.diff_commonSuffix("abcdef1234", "xyz1234"));
+
+    assertEquals("diff_commonSuffix: Whole case.", 4, dmp.diff_commonSuffix("1234", "xyz1234"));
+  }
+
+  public static void testDiffCommonOverlap() {
+    // Detect any suffix/prefix overlap.
+    assertEquals("diff_commonOverlap: Null case.", 0, dmp.diff_commonOverlap("", "abcd"));
+
+    assertEquals("diff_commonOverlap: Whole case.", 3, dmp.diff_commonOverlap("abc", "abcd"));
+
+    assertEquals("diff_commonOverlap: No overlap.", 0, dmp.diff_commonOverlap("123456", "abcd"));
+
+    assertEquals("diff_commonOverlap: Overlap.", 3, dmp.diff_commonOverlap("123456xxx", "xxxabcd"));
+
+    // Some overly clever languages (C#) may treat ligatures as equal to their
+    // component letters.  E.g. U+FB01 == 'fi'
+    assertEquals("diff_commonOverlap: Unicode.", 0, dmp.diff_commonOverlap("fi", "\ufb01i"));
+  }
+
+  public static void testDiffHalfmatch() {
+    // Detect a halfmatch.
+    dmp.Diff_Timeout = 1;
+    assertNull("diff_halfMatch: No match #1.", dmp.diff_halfMatch("1234567890", "abcdef"));
+
+    assertNull("diff_halfMatch: No match #2.", dmp.diff_halfMatch("12345", "23"));
+
+    assertArrayEquals("diff_halfMatch: Single Match #1.", new String[]{"12", "90", "a", "z", "345678"}, dmp.diff_halfMatch("1234567890", "a345678z"));
+
+    assertArrayEquals("diff_halfMatch: Single Match #2.", new String[]{"a", "z", "12", "90", "345678"}, dmp.diff_halfMatch("a345678z", "1234567890"));
+
+    assertArrayEquals("diff_halfMatch: Single Match #3.", new String[]{"abc", "z", "1234", "0", "56789"}, dmp.diff_halfMatch("abc56789z", "1234567890"));
+
+    assertArrayEquals("diff_halfMatch: Single Match #4.", new String[]{"a", "xyz", "1", "7890", "23456"}, dmp.diff_halfMatch("a23456xyz", "1234567890"));
+
+    assertArrayEquals("diff_halfMatch: Multiple Matches #1.", new String[]{"12123", "123121", "a", "z", "1234123451234"}, dmp.diff_halfMatch("121231234123451234123121", "a1234123451234z"));
+
+    assertArrayEquals("diff_halfMatch: Multiple Matches #2.", new String[]{"", "-=-=-=-=-=", "x", "", "x-=-=-=-=-=-=-="}, dmp.diff_halfMatch("x-=-=-=-=-=-=-=-=-=-=-=-=", "xx-=-=-=-=-=-=-="));
+
+    assertArrayEquals("diff_halfMatch: Multiple Matches #3.", new String[]{"-=-=-=-=-=", "", "", "y", "-=-=-=-=-=-=-=y"}, dmp.diff_halfMatch("-=-=-=-=-=-=-=-=-=-=-=-=y", "-=-=-=-=-=-=-=yy"));
+
+    // Optimal diff would be -q+x=H-i+e=lloHe+Hu=llo-Hew+y not -qHillo+x=HelloHe-w+Hulloy
+    assertArrayEquals("diff_halfMatch: Non-optimal halfmatch.", new String[]{"qHillo", "w", "x", "Hulloy", "HelloHe"}, dmp.diff_halfMatch("qHilloHelloHew", "xHelloHeHulloy"));
+
+    dmp.Diff_Timeout = 0;
+    assertNull("diff_halfMatch: Optimal no halfmatch.", dmp.diff_halfMatch("qHilloHelloHew", "xHelloHeHulloy"));
+  }
+
+  public static void testDiffBisect() {
+    // Normal.
+    String a = "cat";
+    String b = "map";
+    // Since the resulting diff hasn't been normalized, it would be ok if
+    // the insertion and deletion pairs are swapped.
+    // If the order changes, tweak this test as required.
+    LinkedList<Diff> diffs = diffList(new Diff(DELETE, "c"), new Diff(INSERT, "m"), new Diff(EQUAL, "a"), new Diff(DELETE, "t"), new Diff(INSERT, "p"));
+    assertEquals("diff_bisect: Normal.", diffs, dmp.diff_bisect(a, b, Long.MAX_VALUE));
+
+    // Timeout.
+    diffs = diffList(new Diff(DELETE, "cat"), new Diff(INSERT, "map"));
+    assertEquals("diff_bisect: Timeout.", diffs, dmp.diff_bisect(a, b, 0));
+  }
+
+  
+  //  MATCH TEST FUNCTIONS
+
+
+  public static void testMatchAlphabet() {
+    // Initialise the bitmasks for Bitap.
+    Map<Character, Integer> bitmask;
+    bitmask = new HashMap<Character, Integer>();
+    bitmask.put('a', 4); bitmask.put('b', 2); bitmask.put('c', 1);
+    assertEquals("match_alphabet: Unique.", bitmask, dmp.match_alphabet("abc"));
+
+    bitmask = new HashMap<Character, Integer>();
+    bitmask.put('a', 37); bitmask.put('b', 18); bitmask.put('c', 8);
+    assertEquals("match_alphabet: Duplicates.", bitmask, dmp.match_alphabet("abcaba"));
+  }
+
+  public static void testMatchBitap() {
+    // Bitap algorithm.
+    dmp.Match_Distance = 100;
+    dmp.Match_Threshold = 0.5f;
+    assertEquals("match_bitap: Exact match #1.", 5, dmp.match_bitap("abcdefghijk", "fgh", 5));
+
+    assertEquals("match_bitap: Exact match #2.", 5, dmp.match_bitap("abcdefghijk", "fgh", 0));
+
+    assertEquals("match_bitap: Fuzzy match #1.", 4, dmp.match_bitap("abcdefghijk", "efxhi", 0));
+
+    assertEquals("match_bitap: Fuzzy match #2.", 2, dmp.match_bitap("abcdefghijk", "cdefxyhijk", 5));
+
+    assertEquals("match_bitap: Fuzzy match #3.", -1, dmp.match_bitap("abcdefghijk", "bxy", 1));
+
+    assertEquals("match_bitap: Overflow.", 2, dmp.match_bitap("123456789xx0", "3456789x0", 2));
+
+    assertEquals("match_bitap: Before start match.", 0, dmp.match_bitap("abcdef", "xxabc", 4));
+
+    assertEquals("match_bitap: Beyond end match.", 3, dmp.match_bitap("abcdef", "defyy", 4));
+
+    assertEquals("match_bitap: Oversized pattern.", 0, dmp.match_bitap("abcdef", "xabcdefy", 0));
+
+    dmp.Match_Threshold = 0.4f;
+    assertEquals("match_bitap: Threshold #1.", 4, dmp.match_bitap("abcdefghijk", "efxyhi", 1));
+
+    dmp.Match_Threshold = 0.3f;
+    assertEquals("match_bitap: Threshold #2.", -1, dmp.match_bitap("abcdefghijk", "efxyhi", 1));
+
+    dmp.Match_Threshold = 0.0f;
+    assertEquals("match_bitap: Threshold #3.", 1, dmp.match_bitap("abcdefghijk", "bcdef", 1));
+
+    dmp.Match_Threshold = 0.5f;
+    assertEquals("match_bitap: Multiple select #1.", 0, dmp.match_bitap("abcdexyzabcde", "abccde", 3));
+
+    assertEquals("match_bitap: Multiple select #2.", 8, dmp.match_bitap("abcdexyzabcde", "abccde", 5));
+
+    dmp.Match_Distance = 10;  // Strict location.
+    assertEquals("match_bitap: Distance test #1.", -1, dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdefg", 24));
+
+    assertEquals("match_bitap: Distance test #2.", 0, dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdxxefg", 1));
+
+    dmp.Match_Distance = 1000;  // Loose location.
+    assertEquals("match_bitap: Distance test #3.", 0, dmp.match_bitap("abcdefghijklmnopqrstuvwxyz", "abcdefg", 24));
+  }
+
+
+  //  PATCH TEST FUNCTIONS
+
+
+  public static void testPatchAddContext() {
+    dmp.Patch_Margin = 4;
+    Patch p;
+    p = dmp.patch_fromText("@@ -21,4 +21,10 @@\n-jump\n+somersault\n").get(0);
+    dmp.patch_addContext(p, "The quick brown fox jumps over the lazy dog.");
+    assertEquals("patch_addContext: Simple case.", "@@ -17,12 +17,18 @@\n fox \n-jump\n+somersault\n s ov\n", p.toString());
+
+    p = dmp.patch_fromText("@@ -21,4 +21,10 @@\n-jump\n+somersault\n").get(0);
+    dmp.patch_addContext(p, "The quick brown fox jumps.");
+    assertEquals("patch_addContext: Not enough trailing context.", "@@ -17,10 +17,16 @@\n fox \n-jump\n+somersault\n s.\n", p.toString());
+
+    p = dmp.patch_fromText("@@ -3 +3,2 @@\n-e\n+at\n").get(0);
+    dmp.patch_addContext(p, "The quick brown fox jumps.");
+    assertEquals("patch_addContext: Not enough leading context.", "@@ -1,7 +1,8 @@\n Th\n-e\n+at\n  qui\n", p.toString());
+
+    p = dmp.patch_fromText("@@ -3 +3,2 @@\n-e\n+at\n").get(0);
+    dmp.patch_addContext(p, "The quick brown fox jumps.  The quick brown fox crashes.");
+    assertEquals("patch_addContext: Ambiguity.", "@@ -1,27 +1,28 @@\n Th\n-e\n+at\n  quick brown fox jumps. \n", p.toString());
+  }
+
+  private static void assertEquals(String error_msg, Object a, Object b) {
+    if (!a.toString().equals(b.toString())) {
+      throw new Error("assertEquals fail:\n Expected: " + a + "\n Actual: " + b
+                      + "\n" + error_msg);
+    }
+  }
+
+  private static void assertArrayEquals(String error_msg, Object[] a, Object[] b) {
+    List<Object> list_a = Arrays.asList(a);
+    List<Object> list_b = Arrays.asList(b);
+    assertEquals(error_msg, list_a, list_b);
+  }
+
+  private static void assertNull(String error_msg, Object n) {
+    if (n != null) {
+      throw new Error("assertNull fail: " + error_msg);
+    }
+  }
+
+  // Private function for quickly building lists of diffs.
+  private static LinkedList<Diff> diffList(Diff... diffs) {
+      return new LinkedList<Diff>(Arrays.asList(diffs));
+  }
+
+  public static void main(String args[]) {
+    dmp = new diff_match_patch();
+
+    testDiffCommonPrefix();
+    testDiffCommonSuffix();
+    testDiffCommonOverlap();
+    testDiffHalfmatch();
+    testDiffBisect();
+
+    testMatchAlphabet();
+    testMatchBitap();
+
+    testPatchAddContext();
+
+    System.out.println("All tests passed.");
+  }
+}


### PR DESCRIPTION
```
We have a bug in the Java implementation of diff-match-patch: users are
unable to follow the following online recipe for Line Mode diffs:

  https://github.com/google/diff-match-patch/wiki/Line-or-Word-Diffs

The problem is that the crucial methods needed by this recipe are marked
as "protected" in the diff_match_patch class, meaning they cannot be
invoked by typical user application code since that code is neither a
subclass of nor should it be in the same package as
diff_match_patch. The most reasonable workaround for users is to
artificially relocate their calling classes into the
"name.fraser.neil.plaintext" package, but this is a bad solution since
it suggests that all line-mode-diff-capable user code also belongs to
the diff-match-patch project.

The solution in this PR is to:

(1) Mark needed methods and one class as "public" rather than
    "protected"

(2) Split the test class in two:

                              diff_match_patch_apitest
                             /                 ^^^^^^^
      diff_match_patch_test <
                             \
                              diff_match_patch_impltest
                                               ^^^^^^^^

    The apitest class contains the majority of the original test, since
    the majority of tested methods are already marked as "public" and
    (presumably) must be on the public API of our library. This test
    would not compile or run cleanly until we made the "protected" -->
    "public" changes in (1).

    The impltest class contains the smaller number of tests from the
    original class which were targeting protected methods that
    (presumably) are not on the public API of our library.

Other solutions are obviously possible: the simplest solution is just to
make the protected-->public changes in (1) and not bother to restructure
the test. I'm willing to accept this solution if the maintainers don't
want to make such a big change to the test, but I do think we're in a
better situation if we don't allow our public API tests to live in the
same package as our implementation tests.

NOTE: I saw that we have the same problem in some other languages which
support method privacy-- for example the C++ implementation has this
problem and currently uses "friend" in the diff_match_patch class to
allow diff_match_patch_test to access protected members. This PR does
not attempt to fix those other languages, since I am not an expert.
```